### PR TITLE
Fixed deprecation warning from Django 1.8

### DIFF
--- a/sendsms/api.py
+++ b/sendsms/api.py
@@ -1,7 +1,12 @@
 #-*- coding: utf-8 -*-
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 from sendsms.utils import load_object
 
 

--- a/sendsms/utils.py
+++ b/sendsms/utils.py
@@ -1,5 +1,9 @@
 #-*- coding: utf-8 -*-
-from importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 
 def load_object(import_path):
     """


### PR DESCRIPTION
This pull fixes issue #11 


 - Warning `RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.` is no longer raised when using Django 1.8
 - Earlier than Py 2.7 and Dj 1.4 still work by using older importlib in Django