### PR TITLE
Use newer twilio API to fix 160 character limit

### DIFF
--- a/sendsms/backends/twiliorest.py
+++ b/sendsms/backends/twiliorest.py
@@ -15,7 +15,7 @@ class SmsBackend(BaseSmsBackend):
         for message in messages:
             for to in message.to:
                 try:
-                    msg = client.sms.messages.create(
+                    msg = client.messages.create(
                         to=to,
                         from_=message.from_phone,
                         body=message.body


### PR DESCRIPTION
See http://stackoverflow.com/questions/22028278/send-sms-of-more-than-160-characters-in-python-using-twilio