### PR TITLE
fix twilio import error

### DIFF
--- a/sendsms/backends/twiliorest.py
+++ b/sendsms/backends/twiliorest.py
@@ -26,6 +26,6 @@ class SmsBackend(BaseSmsBackend):
                         from_=message.from_phone,
                         body=message.body
                     )
-                except Exception as e:
+                except:
                     if not self.fail_silently:
-                        raise Exception("Error: " + str(e))
+                        raise

--- a/sendsms/backends/twiliorest.py
+++ b/sendsms/backends/twiliorest.py
@@ -1,13 +1,19 @@
 #-*- coding: utf-8 -*-
+
 """
 this backend requires the twilio python library: http://pypi.python.org/pypi/twilio/
 """
-from twilio.rest import TwilioRestClient
+try:
+    from twilio.rest import TwilioRestClient
+except ImportError:
+    from twilio.rest import Client as TwilioRestClient
+
 from django.conf import settings
 from sendsms.backends.base import BaseSmsBackend
 
 TWILIO_ACCOUNT_SID = getattr(settings, 'SENDSMS_TWILIO_ACCOUNT_SID', '')
 TWILIO_AUTH_TOKEN = getattr(settings, 'SENDSMS_TWILIO_AUTH_TOKEN', '')
+
 
 class SmsBackend(BaseSmsBackend):
     def send_messages(self, messages):
@@ -15,11 +21,11 @@ class SmsBackend(BaseSmsBackend):
         for message in messages:
             for to in message.to:
                 try:
-                    msg = client.messages.create(
+                    client.messages.create(
                         to=to,
                         from_=message.from_phone,
                         body=message.body
                     )
-                except:
+                except Exception as e:
                     if not self.fail_silently:
-                        raise
+                        raise Exception("Error: " + str(e))


### PR DESCRIPTION
@stefanfoulis This PR fixes the issue `ImportError: cannot import name 'TwilioRestClient'` as the twilio SDK changed it's API in recent versions. Tested with `twilio==6.0.0`