### PR TITLE
fix twilio backward compatibility for python 3

### DIFF
--- a/sendsms/backends/twiliorest.py
+++ b/sendsms/backends/twiliorest.py
@@ -4,7 +4,7 @@
 this backend requires the twilio python library: http://pypi.python.org/pypi/twilio/
 """
 import twilio
-if twilio.__version__ > 5:
+if int(twilio.__version_info__[0]) > 5:
     TWILIO_5 = False
     from twilio.rest import Client as TwilioRestClient
 else:


### PR DESCRIPTION
Turns out the code I copied from here for the twilio backward compatibility stuff doesn't work for python 3: https://github.com/sacren/salt/blob/887336c6deaaad6f9ad4948b69472bd043962d56/salt/modules/twilio_notify.py

We need to grab the major version from here: https://github.com/twilio/twilio-python/blob/master/twilio/__init__.py#L2

It looks like really old versions of the library have that too: https://github.com/twilio/twilio-python/blob/3.6.2/twilio/__init__.py#L1