### PR TITLE
fix twilio backward compatibility for py3 & run py3 tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
 install: pip install tox-travis coveralls
 script: tox
 branches:

--- a/sendsms/backends/twiliorest.py
+++ b/sendsms/backends/twiliorest.py
@@ -4,7 +4,7 @@
 this backend requires the twilio python library: http://pypi.python.org/pypi/twilio/
 """
 import twilio
-if twilio.__version__ > 5:
+if int(twilio.__version_info__[0]) > 5:
     TWILIO_5 = False
     from twilio.rest import Client as TwilioRestClient
 else:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'smssluzbacz': ['smssluzbacz-api'],
         'rq': ['django_rq'],
     },
+    test_suite="test",
     tests_require=[
         'mock',
         'django',

--- a/test.py
+++ b/test.py
@@ -29,7 +29,9 @@ if not settings.configured:
                 'URL': 'redis://localhost',
                 'DEFAULT_TIMEOUT': 500,
             }
-        }
+        },
+        RQ_SENDSMS_BACKEND='sendsms.backends.locmem.SmsBackend',
+        CELERY_SENDSMS_BACKEND='sendsms.backends.locmem.SmsBackend',
     )
 
 


### PR DESCRIPTION
Fixes #31

This bug slipped by because travis isn't running the python 3 tests: https://github.com/stefanfoulis/django-sendsms/pull/34

This PR makes travis run the tests on python 3.5 and 3.6 too.

Edit: This also fixes the twilio backward compatibility code for python 3. I added https://github.com/stefanfoulis/django-sendsms/pull/34 to this PR so we can see the passing tests before we merge.